### PR TITLE
CI/CD: Add release-aware Docker tagging and APP_VERSION injection

### DIFF
--- a/.github/workflows/Build and Release.yml
+++ b/.github/workflows/Build and Release.yml
@@ -3,7 +3,13 @@ name: Build and Deploy
 
 on:
   push:
-    branches: ["*"]
+    branches:
+      - main
+  pull_request:
+    branches:
+      - dev
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:
@@ -19,10 +25,10 @@ concurrency:
 
 jobs:
   # --------------------
-  # TESTS (every push)
+  # Formatter and Linter (every push)
   # --------------------
-  test:
-    name: Run pre-commit checks
+  formatLintAndTest:
+    name: Format, Lint and Test Code
     runs-on: ubuntu-latest
 
     steps:
@@ -32,7 +38,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      
+
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:
@@ -44,21 +50,35 @@ jobs:
       - name: Run pre-commit (all files)
         run: pre-commit run --all-files
 
+      - name: Unit test
+        run: echo "unit tests"
+
 
   build:
     name: Build & Push Docker Image
-    needs: test
-    if: needs.test.result == 'success'
+    needs: formatLintAndTest
     runs-on: ubuntu-latest
-
     outputs:
-      image_tag: ${{ steps.sha.outputs.tag }}
+      image_tag: ${{ steps.set_tag.outputs.IMAGE_TAG }}
 
     steps:
       - uses: actions/checkout@v5
 
-      - id: sha
-        run: echo "tag=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+      - id: set_tag
+        run: |
+          SHORT_SHA=${GITHUB_SHA::7}
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            echo "IMAGE_TAG=${GITHUB_REF_NAME}-${SHORT_SHA}" >> $GITHUB_OUTPUT
+          else
+            echo "IMAGE_TAG=${SHORT_SHA}" >> $GITHUB_OUTPUT
+
+      - name: Set APP_VERSION
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            echo "APP_VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          else
+            echo "APP_VERSION=Pre-release" >> $GITHUB_ENV
+
 
       - uses: docker/login-action@v2
         with:
@@ -66,8 +86,9 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - run: |
-          docker build -t tiggy081/$IMAGE_NAME:${{ steps.sha.outputs.tag }} .
-          docker push tiggy081/$IMAGE_NAME:${{ steps.sha.outputs.tag }}
+          docker build -t tiggy081/$IMAGE_NAME:${{ steps.set_tag.outputs.IMAGE_TAG }} .
+          docker push tiggy081/$IMAGE_NAME:${{ steps.set_tag.outputs.IMAGE_TAG }}
+
 
   # --------------------
   # DEPLOY STG
@@ -95,7 +116,7 @@ jobs:
   # DEPLOY PROD (manual approval)
   # --------------------
   deploy-prod:
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'release'
     name: Deploy to PROD
     needs: [deploy-stg, build]
     runs-on: ubuntu-latest

--- a/app.py
+++ b/app.py
@@ -1,5 +1,7 @@
 import matplotlib
 
+import os
+
 matplotlib.use("Agg")  # headless for Docker
 import io
 
@@ -18,6 +20,7 @@ current_plot = None
 def index():
     global current_plot
     result = None
+    version = os.getenv("APP_VERSION", "Pre-release")
 
     if request.method == "POST":
         try:
@@ -78,7 +81,7 @@ def index():
             "plot": "/plot.png",  # points to new route
         }
 
-    return render_template("index.html", result=result)
+    return render_template("index.html", result=result, version=version)
 
 
 @app.route("/plot.png")

--- a/templates/index.html
+++ b/templates/index.html
@@ -95,7 +95,7 @@
 <body>
 
 <h2>Mortgage Payment and Amortization Calculator</h2>
-<h3>Version 1.2.0</h3>
+<h3>Version {{ version }}</h3>
 
 <form method="POST" onsubmit ="stripCommas(this)">
     <label>Mortgage Amount ($)</label>


### PR DESCRIPTION
- Modify GitHub Actions workflow to generate Docker image tags with SHA for normal pushes 
  and include release version for official GitHub releases.
- Inject APP_VERSION into the application dynamically:
    - "Pre-release" for staging / non-release builds
    - Release version (tag) for production builds
- Ensure deployment jobs respect branch/event triggers:
    - Main branch pushes deploy to staging
    - Release events deploy to production
- Refactor workflow steps for proper YAML structure and job scoping
